### PR TITLE
simplify deploys significantly

### DIFF
--- a/consul/README.md
+++ b/consul/README.md
@@ -11,8 +11,6 @@
 
 
 ## <a name="pkg-index">Index</a>
-* [func CurrentDeploymentTagURL(app, env string) string](#CurrentDeploymentTagURL)
-* [func CurrentTag(app, env string) (string, error)](#CurrentTag)
 * [func Delete(app, deployEnv, url string, keys []string) error](#Delete)
 * [func EnvURL(app, env string) string](#EnvURL)
 * [func Read(url string) (map[string]string, error)](#Read)
@@ -29,23 +27,7 @@
 
 
 
-## <a name="CurrentDeploymentTagURL">func</a> [CurrentDeploymentTagURL](/src/target/api.go?s=4738:4790#L179)
-``` go
-func CurrentDeploymentTagURL(app, env string) string
-```
-CurrentDeploymentTagURL returns URL to fetch currently deployed tag
-
-
-
-## <a name="CurrentTag">func</a> [CurrentTag](/src/target/api.go?s=3722:3770#L141)
-``` go
-func CurrentTag(app, env string) (string, error)
-```
-CurrentTag returns the last deployed tag for app + env
-
-
-
-## <a name="Delete">func</a> [Delete](/src/target/api.go?s=2812:2872#L111)
+## <a name="Delete">func</a> [Delete](/src/target/api.go?s=2849:2909#L114)
 ``` go
 func Delete(app, deployEnv, url string, keys []string) error
 ```
@@ -53,7 +35,7 @@ Delete removes key/values from Consul by given keys
 
 
 
-## <a name="EnvURL">func</a> [EnvURL](/src/target/api.go?s=4528:4563#L173)
+## <a name="EnvURL">func</a> [EnvURL](/src/target/api.go?s=4062:4097#L160)
 ``` go
 func EnvURL(app, env string) string
 ```
@@ -69,7 +51,7 @@ Read returns ENV for given consul KV URL
 
 
 
-## <a name="TxnURL">func</a> [TxnURL](/src/target/api.go?s=5017:5037#L186)
+## <a name="TxnURL">func</a> [TxnURL](/src/target/api.go?s=4250:4270#L166)
 ``` go
 func TxnURL() string
 ```

--- a/consul/api.go
+++ b/consul/api.go
@@ -153,25 +153,6 @@ func Delete(app, deployEnv, url string, keys []string) error {
 	return nil
 }
 
-// CurrentTag returns the last deployed tag for app + env
-func CurrentTag(app, env string) (string, error) {
-	resp, err := http.Get(CurrentDeploymentTagURL(app, env))
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusForbidden {
-		return "", fmt.Errorf("ACL does not allow you to run comand for %s %s", app, env)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		return "", fmt.Errorf("No app found %s %s", app, env)
-	}
-
-	tag, err := ioutil.ReadAll(resp.Body)
-	return string(tag), err
-}
-
 func envMap(kvs []KVPair) map[string]string {
 	m := make(map[string]string)
 	for _, env := range kvs {
@@ -189,13 +170,6 @@ func envMap(kvs []KVPair) map[string]string {
 func EnvURL(app, env string) string {
 	host := viper.GetString("consul_host")
 	return fmt.Sprintf("%s/v1/kv/env/%s/%s", host, app, env)
-}
-
-// CurrentDeploymentTagURL returns URL to fetch currently deployed tag
-func CurrentDeploymentTagURL(app, env string) string {
-	host := viper.GetString("consul_host")
-	token := viper.GetString("consul_token")
-	return fmt.Sprintf("%s/v1/kv/deploys/%s/%s/current?raw&token=%s", host, app, env, token)
 }
 
 // TxnURL returns a Consul transaction (txn) URL

--- a/consul/api_test.go
+++ b/consul/api_test.go
@@ -84,28 +84,6 @@ func TestEnvURL(t *testing.T) {
 	}
 }
 
-func TestCurrentDeploymentTagURL(t *testing.T) {
-	cases := []struct {
-		app string
-		env string
-	}{
-		{app: "foo", env: "stage"},
-		{app: "foo", env: "production"},
-	}
-	ch := "https://consul.yodawg.com"
-	token := "abc123"
-	viper.Set("consul_host", ch)
-	viper.Set("consul_token", token)
-
-	for _, test := range cases {
-		exp := fmt.Sprintf("%s/v1/kv/deploys/%s/%s/current?raw&token=%s", ch, test.app, test.env, token)
-		u := CurrentDeploymentTagURL(test.app, test.env)
-		if exp != u {
-			t.Errorf("expected %s but got %s", exp, u)
-		}
-	}
-}
-
 // TestApp represents a test app
 type TestApp struct {
 	App, Env string

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -12,12 +12,8 @@
 
 ## <a name="pkg-index">Index</a>
 * [func AllowedToManage(app, env string) (bool, error)](#AllowedToManage)
-* [func BeginDeploy(app, env string) error](#BeginDeploy)
-* [func CurrentTag(app, env string) (string, error)](#CurrentTag)
-* [func FinishDeploy(app, env string) error](#FinishDeploy)
 * [func GithubDiffLink(app, prev, tag string) string](#GithubDiffLink)
 * [func MarathonGroupID(app, env string) string](#MarathonGroupID)
-* [func UpdateReleaseTags(app, env, tag, prev string) error](#UpdateReleaseTags)
 * [func Watch(id string) error](#Watch)
 * [type Deployment](#Deployment)
 
@@ -29,7 +25,7 @@
 
 
 
-## <a name="AllowedToManage">func</a> [AllowedToManage](/src/target/utils.go?s=378:429#L15)
+## <a name="AllowedToManage">func</a> [AllowedToManage](/src/target/utils.go?s=367:418#L14)
 ``` go
 func AllowedToManage(app, env string) (bool, error)
 ```
@@ -38,31 +34,7 @@ an app/env
 
 
 
-## <a name="BeginDeploy">func</a> [BeginDeploy](/src/target/utils.go?s=1271:1310#L52)
-``` go
-func BeginDeploy(app, env string) error
-```
-BeginDeploy checks if Consul ACL allows deployments for
-
-
-
-## <a name="CurrentTag">func</a> [CurrentTag](/src/target/utils.go?s=4843:4891#L195)
-``` go
-func CurrentTag(app, env string) (string, error)
-```
-CurrentTag returns the currently deployed git tag for an app and environment
-
-
-
-## <a name="FinishDeploy">func</a> [FinishDeploy](/src/target/utils.go?s=2202:2242#L86)
-``` go
-func FinishDeploy(app, env string) error
-```
-FinishDeploy removes deployment lock after a successful deploy
-
-
-
-## <a name="GithubDiffLink">func</a> [GithubDiffLink](/src/target/utils.go?s=5499:5548#L218)
+## <a name="GithubDiffLink">func</a> [GithubDiffLink](/src/target/utils.go?s=2211:2260#L93)
 ``` go
 func GithubDiffLink(app, prev, tag string) string
 ```
@@ -70,7 +42,7 @@ GithubDiffLink returns a GitHub diff link to view deployment changes
 
 
 
-## <a name="MarathonGroupID">func</a> [MarathonGroupID](/src/target/utils.go?s=5325:5369#L213)
+## <a name="MarathonGroupID">func</a> [MarathonGroupID](/src/target/utils.go?s=2037:2081#L88)
 ``` go
 func MarathonGroupID(app, env string) string
 ```
@@ -78,17 +50,7 @@ MarathonGroupID returns a Marathon Group id for an app and env
 
 
 
-## <a name="UpdateReleaseTags">func</a> [UpdateReleaseTags](/src/target/utils.go?s=3890:3946#L156)
-``` go
-func UpdateReleaseTags(app, env, tag, prev string) error
-```
-UpdateReleaseTags updates the deployment tags in Consul KV registry
-`deploys/{app}/{env}/current` points to the currently deployed tag
-`deploys/{app}/{env}/previous` points to the previously deployed tag
-
-
-
-## <a name="Watch">func</a> [Watch](/src/target/utils.go?s=2977:3004#L117)
+## <a name="Watch">func</a> [Watch](/src/target/utils.go?s=1271:1298#L51)
 ``` go
 func Watch(id string) error
 ```
@@ -97,7 +59,7 @@ Watch watches a Marathon deployment and handles success or failure
 
 
 
-## <a name="Deployment">type</a> [Deployment](/src/target/utils.go?s=254:303#L9)
+## <a name="Deployment">type</a> [Deployment](/src/target/utils.go?s=243:292#L8)
 ``` go
 type Deployment struct {
     ID string `json:"id"`

--- a/deployment/utils.go
+++ b/deployment/utils.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os/user"
 	"strings"
 	"time"
 
@@ -58,71 +57,6 @@ func AllowedToManage(app, env string) (bool, error) {
 	return true, nil
 }
 
-// BeginDeploy checks if Consul ACL allows deployments for
-func BeginDeploy(app, env string) error {
-	u, _ := user.Current()
-	val := fmt.Sprintf("%s-%s", u.Username, time.Now().Format("2006-01-02-15:04:05"))
-	var txn []*consul.TxnItem
-	txn = append(txn, &consul.TxnItem{
-		KV: &consul.KVPair{
-			Key:   fmt.Sprintf("deploys/%s/%s/lock", app, env),
-			Value: base64.StdEncoding.EncodeToString([]byte(val)),
-			Verb:  "set",
-		},
-	})
-	client := &http.Client{}
-	body, err := json.Marshal(txn)
-	if err != nil {
-		return err
-	}
-	url := consul.TxnURL()
-	req, _ := http.NewRequest("PUT", url, bytes.NewReader(body))
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-		return fmt.Errorf("Your consul_token is not allowed to deploy %s %s: %s", app, env, string(b))
-	}
-	return nil
-}
-
-// FinishDeploy removes deployment lock after a successful deploy
-func FinishDeploy(app, env string) error {
-	var txn []*consul.TxnItem
-	txn = append(txn, &consul.TxnItem{
-		KV: &consul.KVPair{
-			Key:  fmt.Sprintf("deploys/%s/%s/lock", app, env),
-			Verb: "delete",
-		},
-	})
-	client := &http.Client{}
-	body, err := json.Marshal(txn)
-	if err != nil {
-		return err
-	}
-	url := consul.TxnURL()
-	req, _ := http.NewRequest("PUT", url, bytes.NewReader(body))
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-		return fmt.Errorf("failed to remove deployment lock in Consul: %s\n%s\n", resp.Status, string(b))
-	}
-	return nil
-}
-
 // Watch watches a Marathon deployment and handles success or failure
 func Watch(id string) error {
 	if id == "" {
@@ -158,65 +92,6 @@ func Watch(id string) error {
 	}
 	fmt.Println("DONE")
 	return nil
-}
-
-// UpdateReleaseTags updates the deployment tags in Consul KV registry
-// `deploys/{app}/{env}/current` points to the currently deployed tag
-// `deploys/{app}/{env}/previous` points to the previously deployed tag
-func UpdateReleaseTags(app, env, tag, prev string) error {
-	m := map[string]string{
-		"current":  tag,
-		"previous": prev,
-	}
-
-	var txn []*consul.TxnItem
-	for k, v := range m {
-		txn = append(txn, &consul.TxnItem{
-			KV: &consul.KVPair{
-				Key:   fmt.Sprintf("deploys/%s/%s/%s", app, env, k),
-				Value: base64.StdEncoding.EncodeToString([]byte(v)),
-				Verb:  "set",
-			},
-		})
-	}
-	client := &http.Client{}
-	body, err := json.Marshal(txn)
-	if err != nil {
-		return err
-	}
-	url := consul.TxnURL()
-	req, _ := http.NewRequest("PUT", url, bytes.NewReader(body))
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-		return fmt.Errorf("failed to update release tags in Consul: %s\n%s", resp.Status, string(b))
-	}
-	return nil
-}
-
-// CurrentTag returns the currently deployed git tag for an app and environment
-func CurrentTag(app, env string) (string, error) {
-	url := consul.CurrentDeploymentTagURL(app, env)
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusOK {
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return "", err
-		}
-		return string(b), nil
-	}
-	return "", fmt.Errorf("could not fetch current release tag: %s", resp.Status)
 }
 
 // MarathonGroupID returns a Marathon Group id for an app and env

--- a/deployment/utils_test.go
+++ b/deployment/utils_test.go
@@ -2,9 +2,6 @@ package deployment
 
 import (
 	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -25,108 +22,6 @@ func TestMarathonGroupID(t *testing.T) {
 		exp := "/" + strings.Join([]string{test.app, test.env}, "-")
 		if id != exp {
 			t.Errorf("expected %s but got %s", exp, id)
-		}
-	}
-}
-
-func TestBeginDeploy(t *testing.T) {
-	cases := []struct {
-		app     string
-		env     string
-		allowed bool
-	}{
-		{app: "yo", env: "stage", allowed: true},
-		{app: "badboy", env: "stage", allowed: false},
-	}
-
-	for _, test := range cases {
-		ts := createConsulDeployLockServer(test.allowed)
-		viper.Set("consul_host", ts.URL)
-		err := BeginDeploy(test.app, test.env)
-		if test.allowed && err != nil {
-			t.Errorf("expected error to be nil got: %v", err)
-		}
-		if !test.allowed && err == nil {
-			t.Errorf("expected error but got nil")
-		}
-	}
-}
-
-func TestFinishDeploy(t *testing.T) {
-	cases := []struct {
-		app     string
-		env     string
-		allowed bool
-	}{
-		{app: "yo", env: "stage", allowed: true},
-		{app: "badboy", env: "stage", allowed: false},
-	}
-
-	for _, test := range cases {
-		ts := createConsulDeployLockServer(test.allowed)
-		viper.Set("consul_host", ts.URL)
-		err := FinishDeploy(test.app, test.env)
-		if test.allowed && err != nil {
-			t.Errorf("expected error to be nil got: %v", err)
-		}
-		if !test.allowed && err == nil {
-			t.Errorf("expected error but got nil")
-		}
-	}
-}
-
-func TestUpdateReleaseTags(t *testing.T) {
-	cases := []struct {
-		app  string
-		env  string
-		curr string
-		prev string
-		ok   bool
-	}{
-		{app: "yo", env: "stage", curr: "1.2.3", prev: "1.2.2", ok: true},
-		{app: "badboy", env: "stage", curr: "4.5.6", prev: "4.5.7", ok: false},
-	}
-
-	for _, test := range cases {
-		ts := createConsulDeployLockServer(test.ok)
-		viper.Set("consul_host", ts.URL)
-		err := UpdateReleaseTags(test.app, test.env, test.curr, test.prev)
-		if test.ok && err != nil {
-			t.Errorf("expected error to be nil but got: %v", err)
-		}
-		if !test.ok && err == nil {
-			t.Errorf("expected error but got nil")
-		}
-	}
-}
-
-func TestCurrentTag(t *testing.T) {
-	cases := []struct {
-		app string
-		env string
-		tag string
-		ok  bool
-	}{
-		{app: "yo", env: "stage", tag: "1.2.3", ok: true},
-		{app: "badboy", env: "stage", tag: "4.5.6", ok: false},
-	}
-
-	for _, test := range cases {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !test.ok {
-				w.WriteHeader(http.StatusNotFound)
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, test.tag)
-		}))
-		viper.Set("consul_host", ts.URL)
-		tag, err := CurrentTag(test.app, test.env)
-		if test.ok && err != nil {
-			t.Errorf("expected error to be nil but got: %v", err)
-		}
-		if err == nil && test.tag != tag {
-			t.Errorf("expected tag '%s' but got '%s'", test.tag, tag)
 		}
 	}
 }
@@ -163,15 +58,4 @@ func TestGithubDiffLink(t *testing.T) {
 			}
 		}
 	}
-}
-
-func createConsulDeployLockServer(ok bool) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !ok {
-			w.WriteHeader(http.StatusConflict)
-			io.WriteString(w, `{"Results":null,"Errors":[{"OpIndex":0,"What":"Permission denied"}]}`)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
 }

--- a/marathon/README.md
+++ b/marathon/README.md
@@ -12,7 +12,7 @@
 
 ## <a name="pkg-index">Index</a>
 * [func AssertAppExistsInGroup(app, env, typ string) error](#AssertAppExistsInGroup)
-* [func Deploy(app, env, tag string) error](#Deploy)
+* [func Deploy(app, env, tag string) (string, error)](#Deploy)
 * [func List(app, env string) error](#List)
 * [func Scale(group *Group, rules map[string]int) (string, error)](#Scale)
 * [type App](#App)
@@ -44,9 +44,9 @@ and returns an error if it does not
 
 
 
-## <a name="Deploy">func</a> [Deploy](/src/target/deploy.go?s=186:225#L4)
+## <a name="Deploy">func</a> [Deploy](/src/target/deploy.go?s=186:235#L4)
 ``` go
-func Deploy(app, env, tag string) error
+func Deploy(app, env, tag string) (string, error)
 ```
 Deploy deploys a given marathon app, env and tag
 

--- a/marathon/deploy.go
+++ b/marathon/deploy.go
@@ -11,49 +11,51 @@ import (
 )
 
 // Deploy deploys a given marathon app, env and tag
-func Deploy(app, env, tag string) error {
+func Deploy(app, env, tag string) (string, error) {
+	var prev string
 	groups, err := listGroups()
 	if err != nil {
-		return err
+		return prev, err
 	}
 
 	for _, g := range groups.Groups {
 		if g.ID == deployment.MarathonGroupID(app, env) {
 			for _, a := range g.Apps {
 				if a.IsApp(app) {
+					prev = a.ReleaseTag()
 					a.UpdateReleaseTag(tag)
 				}
 			}
 			j, err := json.Marshal(g)
 			if err != nil {
-				return err
+				return prev, err
 			}
 			client := &http.Client{}
 			req, _ := http.NewRequest("PUT", updateGroupURL(), bytes.NewReader(j))
 			req.Header.Set("Content-Type", "application/json")
 			resp, err := client.Do(req)
 			if err != nil {
-				return err
+				return prev, err
 			}
 			defer resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
 				b, err := ioutil.ReadAll(resp.Body)
 				if err != nil {
-					return err
+					return prev, err
 				}
-				return fmt.Errorf("failed to deploy: %s\n%s\n", resp.Status, string(b))
+				return prev, fmt.Errorf("failed to deploy: %s\n%s\n", resp.Status, string(b))
 			}
 			d := &deploymentResponse{}
 			if err := json.NewDecoder(resp.Body).Decode(d); err != nil {
-				return err
+				return prev, err
 			}
 			if err := deployment.Watch(d.ID); err != nil {
-				return err
+				return prev, err
 			}
 
-			return nil
+			return prev, nil
 		}
 	}
 
-	return nil
+	return prev, nil
 }

--- a/vault/README.md
+++ b/vault/README.md
@@ -25,7 +25,7 @@
 
 
 
-## <a name="SecretsURL">func</a> [SecretsURL](/src/target/api.go?s=3888:3927#L145)
+## <a name="SecretsURL">func</a> [SecretsURL](/src/target/api.go?s=3958:3997#L151)
 ``` go
 func SecretsURL(app, env string) string
 ```
@@ -49,7 +49,7 @@ Secrets represents Vault key/value pairs for a prefix
 
 
 
-### <a name="Delete">func</a> [Delete](/src/target/api.go?s=1934:2002#L73)
+### <a name="Delete">func</a> [Delete](/src/target/api.go?s=1969:2037#L76)
 ``` go
 func Delete(url string, keys []string, s *Secrets) (*Secrets, error)
 ```


### PR DESCRIPTION
Deletes complex code and makes deploys more reliable also 🕊 

* stop doing Consul KV mutex for deploys
* trust Marathon API to block concurrent deploys (ultra-rare occurrence anyway)
* prevent failed deploy from leaving stale deploy tags in Consul KV
* allow redeployment of same tag (not needed often but nice to have that option)