### PR TITLE
enable list/deploy to work w/ k8s stateful sets

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -57,7 +57,7 @@ NOTE: tag must exist in docker registry
 		var err error
 
 		if viper.GetString("kubernetes_host") != "" {
-			k8sClient, err := k8s.NewClient()
+			k8sClient, err := k8s.NewClient(viper.GetString("kubernetes_namespace"))
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -35,7 +35,7 @@ var listCmd = &cobra.Command{
 		}
 
 		if viper.GetString("kubernetes_host") != "" {
-			k8sClient, err := k8s.NewClient()
+			k8sClient, err := k8s.NewClient(viper.GetString("kubernetes_namespace"))
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/example_duncan.yml
+++ b/example_duncan.yml
@@ -2,6 +2,7 @@
 ---
 marathon_host: https://mesos.host
 # kubernetes_host: https://kube.host
+kubernetes_namespace: pipeline
 
 # for autoscaling commands
 slythe_host: https://slythe.host

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"k8s.io/client-go/kubernetes"
@@ -10,11 +11,15 @@ import (
 
 // KubeAPI performs all the Kubernetes API operations
 type KubeAPI struct {
-	Client kubernetes.Interface
+	Client    kubernetes.Interface
+	Namespace string
 }
 
 // NewClient returns a new KubeAPI client
-func NewClient() (*KubeAPI, error) {
+func NewClient(namespace string) (*KubeAPI, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("must supply kubernetes_namespace in duncan.yml")
+	}
 	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "config")
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -25,5 +30,8 @@ func NewClient() (*KubeAPI, error) {
 		return nil, err
 	}
 
-	return &KubeAPI{Client: clientset}, nil
+	return &KubeAPI{
+		Client:    clientset,
+		Namespace: namespace,
+	}, nil
 }

--- a/k8s/deploy.go
+++ b/k8s/deploy.go
@@ -14,7 +14,7 @@ import (
 // given app and env if it exists. First checks Kubernetes Deployment API
 // and then Stateful Sets API
 func (k *KubeAPI) CurrentTag(app, env, repo string) (string, error) {
-	deploymentsClient := k.Client.AppsV1().Deployments("pipeline")
+	deploymentsClient := k.Client.AppsV1().Deployments(k.Namespace)
 	deploymentList, err := deploymentsClient.List(metav1.ListOptions{})
 	if err != nil {
 		return "", err
@@ -26,7 +26,7 @@ func (k *KubeAPI) CurrentTag(app, env, repo string) (string, error) {
 		}
 	}
 
-	ssClient := k.Client.AppsV1().StatefulSets("pipeline")
+	ssClient := k.Client.AppsV1().StatefulSets(k.Namespace)
 	ssList, err := ssClient.List(metav1.ListOptions{})
 	if err != nil {
 		return "", err
@@ -68,7 +68,7 @@ func findTag(app, env string, template corev1.PodTemplateSpec) string {
 }
 
 func (k *KubeAPI) updateDeployment(app, env, tag, repo string) error {
-	deploymentsClient := k.Client.AppsV1().Deployments("pipeline")
+	deploymentsClient := k.Client.AppsV1().Deployments(k.Namespace)
 
 	list, err := deploymentsClient.List(metav1.ListOptions{})
 	if err != nil {
@@ -103,7 +103,7 @@ func (k *KubeAPI) updateDeployment(app, env, tag, repo string) error {
 }
 
 func (k *KubeAPI) updateStatefulSet(app, env, tag, repo string) error {
-	ssClient := k.Client.AppsV1().StatefulSets("pipeline")
+	ssClient := k.Client.AppsV1().StatefulSets(k.Namespace)
 
 	ssList, err := ssClient.List(metav1.ListOptions{})
 	if err != nil {

--- a/k8s/list.go
+++ b/k8s/list.go
@@ -25,8 +25,8 @@ func (k *KubeAPI) List(app, env string) error {
 	if env == "" {
 		env = "stage|production"
 	}
-	deploymentsClient := k.Client.AppsV1().Deployments("pipeline")
-	ssClient := k.Client.AppsV1().StatefulSets("pipeline")
+	deploymentsClient := k.Client.AppsV1().Deployments(k.Namespace)
+	ssClient := k.Client.AppsV1().StatefulSets(k.Namespace)
 
 	deploymentList, err := deploymentsClient.List(metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
these changes allow more flexibility in our kubernetes deployments. previously it was assumed everything we want to `duncan list` or `duncan deploy` was a Kubernetes "Deployment". That assumption broke when we added a handful of Stateful Sets and mix and match.

with these changes we can deploy Stateful Sets along w/ any Deployment type Kube objects e.g., our Airflow system