### PR TITLE
duncan list should show k8s cpu/mem limits

### DIFF
--- a/k8s/list.go
+++ b/k8s/list.go
@@ -45,7 +45,7 @@ func (k *KubeAPI) List(app, env string) error {
 	for k, v := range groups {
 		fmt.Println(green(k))
 		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"ID", "Tag", "Instances"})
+		table.SetHeader([]string{"ID", "Tag", "Instances", "CPU", "Mem"})
 		table.AppendBulk(v)
 		table.Render()
 	}
@@ -86,10 +86,14 @@ func addContainerToGroup(groups map[string][][]string, app, env, group, groupEnv
 	if len(parts) > 1 {
 		tag = parts[1]
 	}
+	cpu := container.Resources.Limits["cpu"]
+	mem := container.Resources.Limits["memory"]
 	data = append(data, []string{
 		cyan(container.Name),
 		white(tag),
 		yellow(replicas),
+		cyan(cpu.String()),
+		cyan(mem.String()),
 	})
 
 	parts = strings.Split(group, "-")


### PR DESCRIPTION
now will display cpu/mem limits for apps running in Kubernetes

![screen shot 2018-12-26 at 11 28 31 am](https://user-images.githubusercontent.com/31030/50455202-67a51480-0901-11e9-9ed1-1d9c51b6c1f4.png)
