### PR TITLE
Allow for environments beyond stage/production

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -127,11 +127,6 @@ func validateDeployFlags() {
 		os.Exit(1)
 	}
 
-	if env != "stage" && env != "production" {
-		fmt.Printf("env %s is not a valid deployment environment\n", env)
-		os.Exit(1)
-	}
-
 	// if no --repo flag use app name as repo name
 	// this is important to use
 	if repo == "" {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -29,11 +29,6 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List applications",
 	Run: func(cmd *cobra.Command, args []string) {
-		if env != "" && env != "stage" && env != "production" {
-			fmt.Printf("env %s is not a valid deployment environment\n", env)
-			os.Exit(1)
-		}
-
 		if viper.GetString("kubernetes_cluster") != "" {
 			k8sClient, err := k8s.NewClient()
 			if err != nil {


### PR DESCRIPTION
It seems to be safe to do, since kubernetes definitions have to exist anyway. This way, multiple stage environments are possible.